### PR TITLE
Simple domain service

### DIFF
--- a/config/hooks/pre-push
+++ b/config/hooks/pre-push
@@ -1,5 +1,3 @@
 #!/bin/sh
-cd data-access-services
-mvn checkstyle:check
-# todo specify projects here
-
+mvn -f ./data-access-services/pom.xml checkstyle:check
+mvn -f ./domain-service/credit-application/pom.xml checkstyle:check

--- a/domain-service/credit-application/pom.xml
+++ b/domain-service/credit-application/pom.xml
@@ -11,13 +11,12 @@
     </parent>
 
     <groupId>at.deloittedigital</groupId>
-    <artifactId>credit-application</artifactId>
+    <artifactId>credit-application-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
         <java.version>11</java.version>
         <checkstyle.version>3.1.2</checkstyle.version>
-
     </properties>
 
     <dependencies>

--- a/domain-service/credit-application/pom.xml
+++ b/domain-service/credit-application/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.4.2</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>at.deloittedigital</groupId>
+    <artifactId>credit-application</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <properties>
+        <java.version>11</java.version>
+        <checkstyle.version>3.1.2</checkstyle.version>
+
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${checkstyle.version}</version>
+                <configuration>
+                    <configLocation>../../config/checkstyle/checkstyle.xml</configLocation>
+                    <violationSeverity>warning</violationSeverity>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/CoreBankingCreditApplication.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/CoreBankingCreditApplication.java
@@ -1,0 +1,13 @@
+package at.deloittedigital.core_banking.credit;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CoreBankingCreditApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CoreBankingCreditApplication.class, args);
+    }
+
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/ApiExceptionHandler.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/ApiExceptionHandler.java
@@ -1,0 +1,54 @@
+package at.deloittedigital.core_banking.credit.api;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import at.deloittedigital.core_banking.credit.api.data.error.ApiError;
+import at.deloittedigital.core_banking.credit.api.data.error.ErrorResponse;
+import at.deloittedigital.core_banking.credit.api.data.error.NotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolationException;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Log4j2
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<ErrorResponse> missingParamException(MissingServletRequestParameterException exception) {
+        log.warn("Missing param: {}", exception.getMessage());
+        ErrorResponse response = ErrorResponse.of(exception.getParameterName(), exception.getMessage());
+        return ResponseEntity.status(BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ErrorResponse> validationException(ConstraintViolationException exception) {
+        log.warn("Invalid param: {}", exception.getMessage());
+        List<ApiError> errors = exception
+                .getConstraintViolations()
+                .stream()
+                .map(violation -> new ApiError(violation.getPropertyPath().toString(), violation.getMessage()))
+                .collect(Collectors.toList());
+        ErrorResponse response = ErrorResponse.of(errors);
+        return ResponseEntity.status(BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> notFoundException(NotFoundException exception) {
+        log.warn("Not found: {}", exception.getMessage());
+        ErrorResponse response = ErrorResponse.of(exception.getEntity(), exception.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> exception(Exception exception) {
+        log.error("Unhandled exception", exception);
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(ErrorResponse.of("Error while processing request"));
+    }
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/TestController.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/TestController.java
@@ -1,0 +1,34 @@
+package at.deloittedigital.core_banking.credit.api;
+
+import at.deloittedigital.core_banking.credit.api.data.TestClientResponse;
+import at.deloittedigital.core_banking.credit.api.data.error.NotFoundException;
+import at.deloittedigital.core_banking.credit.domain.CreditApplicationService;
+import at.deloittedigital.core_banking.credit.domain.data.ClientInfo;
+import java.util.Optional;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+public class TestController {
+
+    private final CreditApplicationService creditApplicationService;
+
+    public TestController(CreditApplicationService creditApplicationService) {
+        this.creditApplicationService = creditApplicationService;
+    }
+
+    @GetMapping("/test")
+    public TestClientResponse test(@Valid @NotBlank @RequestParam("clientId") String clientId) {
+        Optional<ClientInfo> clientInfo = creditApplicationService.clientInfo(clientId);
+        if (clientInfo.isEmpty()) {
+            throw new NotFoundException(clientId, "Client not found");
+        }
+        return new TestClientResponse(clientInfo.get());
+    }
+}
+

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/TestController.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/TestController.java
@@ -7,6 +7,7 @@ import at.deloittedigital.core_banking.credit.domain.data.ClientInfo;
 import java.util.Optional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,13 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Validated
+@RequiredArgsConstructor
 public class TestController {
 
     private final CreditApplicationService creditApplicationService;
-
-    public TestController(CreditApplicationService creditApplicationService) {
-        this.creditApplicationService = creditApplicationService;
-    }
 
     @GetMapping("/test")
     public TestClientResponse test(@Valid @NotBlank @RequestParam("clientId") String clientId) {

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/data/TestClientResponse.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/data/TestClientResponse.java
@@ -1,0 +1,40 @@
+package at.deloittedigital.core_banking.credit.api.data;
+
+import static java.util.Collections.singletonList;
+
+import at.deloittedigital.core_banking.credit.api.data.error.ApiError;
+import at.deloittedigital.core_banking.credit.domain.data.ClientInfo;
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TestClientResponse {
+
+    private String clientId;
+    private String firstName;
+    private String lastName;
+    private BigDecimal sumTransactions;
+    private List<ApiError> errors;
+
+    public TestClientResponse(ClientInfo clientInfo) {
+        this.clientId = clientInfo.getClientId();
+        this.firstName = clientInfo.getFirstName();
+        this.lastName = clientInfo.getLastName();
+        this.sumTransactions = clientInfo.getSumTransactions();
+    }
+
+    public static TestClientResponse error(ApiError error) {
+        return TestClientResponse.builder()
+                .errors(singletonList(error))
+                .build();
+    }
+
+}
+

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/data/error/ApiError.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/data/error/ApiError.java
@@ -1,0 +1,15 @@
+package at.deloittedigital.core_banking.credit.api.data.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiError {
+
+    private String value;
+    private String message;
+
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/data/error/ErrorResponse.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/data/error/ErrorResponse.java
@@ -1,0 +1,26 @@
+package at.deloittedigital.core_banking.credit.api.data.error;
+
+import static java.util.Collections.singletonList;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private List<ApiError> errors;
+
+    public static ErrorResponse of(String value, String message) {
+        return new ErrorResponse(singletonList(new ApiError(value, message)));
+    }
+
+    public static ErrorResponse of(String message) {
+        return new ErrorResponse(singletonList(new ApiError("", message)));
+    }
+
+    public static ErrorResponse of(List<ApiError> errors) {
+        return new ErrorResponse(errors);
+    }
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/data/error/NotFoundException.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/api/data/error/NotFoundException.java
@@ -1,0 +1,15 @@
+package at.deloittedigital.core_banking.credit.api.data.error;
+
+public class NotFoundException extends RuntimeException {
+
+    private final String entity;
+
+    public NotFoundException(String entity, String message) {
+        super(message);
+        this.entity = entity;
+    }
+
+    public String getEntity() {
+        return entity;
+    }
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/config/ObjectMapperConfig.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/config/ObjectMapperConfig.java
@@ -1,0 +1,16 @@
+package at.deloittedigital.core_banking.credit.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder() {
+        return new Jackson2ObjectMapperBuilder()
+                .serializationInclusion(JsonInclude.Include.NON_NULL);
+    }
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/config/RestTemplateConfig.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/config/RestTemplateConfig.java
@@ -1,0 +1,16 @@
+package at.deloittedigital.core_banking.credit.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
+
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/CreditDataService.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/CreditDataService.java
@@ -1,0 +1,7 @@
+package at.deloittedigital.core_banking.credit.datasource;
+
+import at.deloittedigital.core_banking.credit.datasource.model.CreditData;
+
+public interface CreditDataService {
+    CreditData query(String clientId);
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/MockCreditDataService.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/MockCreditDataService.java
@@ -1,0 +1,37 @@
+package at.deloittedigital.core_banking.credit.datasource;
+
+import at.deloittedigital.core_banking.credit.datasource.model.CreditData;
+import at.deloittedigital.core_banking.credit.datasource.model.QueryResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+/**
+ * Mock implementation of {@link CreditDataService} until API integration is done.
+ */
+@Service
+@ConditionalOnProperty(name = "core-banking.credit.datasource.mode", havingValue = "mock")
+public class MockCreditDataService implements CreditDataService {
+
+    private final ObjectMapper objectMapper;
+
+    public MockCreditDataService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public CreditData query(String clientId) {
+        try (InputStream is = readMockData()) {
+            QueryResult result = objectMapper.readValue(is, QueryResult.class);
+            return result.getCreditData().filter(clientId);
+        } catch (IOException e) {
+            throw new RuntimeException("Error while loading mock response", e);
+        }
+    }
+
+    private InputStream readMockData() {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream("mock-credit-data.json");
+    }
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/RemoteCreditDataService.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/RemoteCreditDataService.java
@@ -1,0 +1,49 @@
+package at.deloittedigital.core_banking.credit.datasource;
+
+import at.deloittedigital.core_banking.credit.datasource.model.CreditData;
+import at.deloittedigital.core_banking.credit.datasource.model.QueryResult;
+import java.net.URI;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@Log4j2
+@ConditionalOnProperty(name = "core-banking.credit.datasource.mode", havingValue = "remote")
+public class RemoteCreditDataService implements CreditDataService {
+
+    private final RestTemplate restTemplate;
+    private final URI dataServiceUrl;
+
+    public RemoteCreditDataService(
+            RestTemplate restTemplate,
+            @Value("${core-banking.credit.datasource.url}") URI dataServiceUrl) {
+        this.restTemplate = restTemplate;
+        this.dataServiceUrl = dataServiceUrl;
+    }
+
+    @Override
+    public CreditData query(String clientId) {
+        // for testing basic service integration
+        // todo error handling, non-blocking req, response validity check
+        URI endpoint = UriComponentsBuilder
+                .fromUri(dataServiceUrl)
+                .path("/query")
+                .build().toUri();
+        HttpEntity<String> request = new HttpEntity<>("{}");
+        log.info("POST {}", endpoint);
+        QueryResult result = restTemplate.exchange(endpoint, HttpMethod.POST, request, QueryResult.class).getBody();
+        if (result == null) {
+            throw new RestClientException("Data service null response");
+        }
+        log.info("Received data {}", result.getCreditData());
+        return result.getCreditData().filter(clientId);
+    }
+
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/Account.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/Account.java
@@ -1,0 +1,16 @@
+package at.deloittedigital.core_banking.credit.datasource.model;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Account {
+    private String accountId;
+    private LocalDate createdDate;
+    private List<Transaction> transactions;
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/Client.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/Client.java
@@ -1,0 +1,20 @@
+package at.deloittedigital.core_banking.credit.datasource.model;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Client {
+    private String clientId;
+    private String firstName;
+    private String lastName;
+    private String socialSN;
+    private String sex;
+    private LocalDate dateOfBirth;
+    private List<Account> accounts;
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/CreditData.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/CreditData.java
@@ -1,0 +1,24 @@
+package at.deloittedigital.core_banking.credit.datasource.model;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreditData {
+    private List<Client> clients;
+
+    public boolean isEmpty() {
+        return clients == null || clients.isEmpty();
+    }
+
+    public CreditData filter(String clientId) {
+        List<Client> clients = this.clients.stream().filter(c -> clientId.equals(c.getClientId())).collect(toList());
+        return new CreditData(clients);
+    }
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/QueryResult.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/QueryResult.java
@@ -1,0 +1,15 @@
+package at.deloittedigital.core_banking.credit.datasource.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class QueryResult {
+
+    @JsonProperty("data")
+    private CreditData creditData;
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/Transaction.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/Transaction.java
@@ -1,0 +1,19 @@
+package at.deloittedigital.core_banking.credit.datasource.model;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Transaction {
+    private String transactionId;
+    private String accountId;
+    private String accountIban;
+    private String types;
+    private String operation;
+    private BigDecimal amount;
+    private BigDecimal balance;
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/domain/CreditApplicationService.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/domain/CreditApplicationService.java
@@ -1,0 +1,32 @@
+package at.deloittedigital.core_banking.credit.domain;
+
+import at.deloittedigital.core_banking.credit.datasource.CreditDataService;
+import at.deloittedigital.core_banking.credit.datasource.model.Client;
+import at.deloittedigital.core_banking.credit.datasource.model.CreditData;
+import at.deloittedigital.core_banking.credit.domain.data.ClientInfo;
+import at.deloittedigital.core_banking.credit.domain.data.ClientInfoMapper;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreditApplicationService {
+
+    private final CreditDataService creditDataService;
+    private final ClientInfoMapper clientInfoMapper;
+
+    public CreditApplicationService(CreditDataService creditDataService, ClientInfoMapper clientInfoMapper) {
+        this.creditDataService = creditDataService;
+        this.clientInfoMapper = clientInfoMapper;
+    }
+
+    public Optional<ClientInfo> clientInfo(String clientId) {
+        CreditData data = creditDataService.query(clientId);
+        if (data.isEmpty()) {
+            return Optional.empty();
+        } else {
+            Client c = data.getClients().get(0);
+            return Optional.of(clientInfoMapper.map(c));
+        }
+    }
+
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/domain/data/ClientInfo.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/domain/data/ClientInfo.java
@@ -1,0 +1,15 @@
+package at.deloittedigital.core_banking.credit.domain.data;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ClientInfo {
+
+    private String clientId;
+    private String firstName;
+    private String lastName;
+    private BigDecimal sumTransactions;
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/domain/data/ClientInfoMapper.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/domain/data/ClientInfoMapper.java
@@ -1,0 +1,29 @@
+package at.deloittedigital.core_banking.credit.domain.data;
+
+import at.deloittedigital.core_banking.credit.datasource.model.Account;
+import at.deloittedigital.core_banking.credit.datasource.model.Client;
+import at.deloittedigital.core_banking.credit.datasource.model.Transaction;
+import java.math.BigDecimal;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClientInfoMapper {
+
+    public ClientInfo map(Client client) {
+        return ClientInfo.builder()
+                .clientId(client.getClientId())
+                .firstName(client.getFirstName())
+                .lastName(client.getLastName())
+                .sumTransactions(sumTransactions(client.getAccounts()))
+                .build();
+    }
+
+    private BigDecimal sumTransactions(List<Account> accounts) {
+        return accounts.stream()
+                .flatMap(a -> a.getTransactions().stream())
+                .map(Transaction::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+}

--- a/domain-service/credit-application/src/main/resources/application.yml
+++ b/domain-service/credit-application/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: 8080
+  error:
+    whitelabel:
+      enabled: false
+
+core-banking:
+  credit:
+    datasource:
+      mode: "mock"
+      url: ""

--- a/domain-service/credit-application/src/main/resources/mock-credit-data.json
+++ b/domain-service/credit-application/src/main/resources/mock-credit-data.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "clients": [
+      {
+        "clientId": "1234",
+        "firstName": "John",
+        "lastName": "Smith",
+        "accounts": [
+          {
+            "transactions": [
+              {
+                "amount": 12.99
+              },
+              {
+                "amount": -11.99
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/domain-service/credit-application/src/test/java/at/deloittedigital/core_banking/credit/CoreBankingCreditApplicationTests.java
+++ b/domain-service/credit-application/src/test/java/at/deloittedigital/core_banking/credit/CoreBankingCreditApplicationTests.java
@@ -1,8 +1,6 @@
 package at.deloittedigital.core_banking.credit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import at.deloittedigital.core_banking.credit.api.data.TestClientResponse;
@@ -25,10 +23,6 @@ class CoreBankingCreditApplicationTests {
     private ObjectMapper objectMapper;
 
     @Test
-    void contextLoads() {
-    }
-
-    @Test
     void whenCallingTestEndpoint_returnsSumOfTransactions() throws Exception {
 
         String responseBody = mockMvc
@@ -38,8 +32,8 @@ class CoreBankingCreditApplicationTests {
 
         TestClientResponse response = objectMapper.readValue(responseBody, TestClientResponse.class);
 
-        assertNull(response.getErrors());
-        assertEquals(new BigDecimal("1.00"), response.getSumTransactions());
+        assertThat(response.getErrors()).isNull();
+        assertThat(response.getSumTransactions()).isEqualTo(new BigDecimal("1.00"));
 
     }
 
@@ -53,9 +47,8 @@ class CoreBankingCreditApplicationTests {
 
         TestClientResponse response = objectMapper.readValue(responseBody, TestClientResponse.class);
 
-        assertNotNull(response.getErrors());
-        assertEquals(1, response.getErrors().size());
-        assertEquals("ABC321", response.getErrors().get(0).getValue());
+        assertThat(response.getErrors()).hasSize(1);
+        assertThat(response.getErrors().get(0).getValue()).isEqualTo("ABC321");
 
     }
 }

--- a/domain-service/credit-application/src/test/java/at/deloittedigital/core_banking/credit/CoreBankingCreditApplicationTests.java
+++ b/domain-service/credit-application/src/test/java/at/deloittedigital/core_banking/credit/CoreBankingCreditApplicationTests.java
@@ -1,0 +1,61 @@
+package at.deloittedigital.core_banking.credit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import at.deloittedigital.core_banking.credit.api.data.TestClientResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest(properties = {"core-banking.credit.datasource.mode=mock"})
+@AutoConfigureMockMvc
+class CoreBankingCreditApplicationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void contextLoads() {
+    }
+
+    @Test
+    void whenCallingTestEndpoint_returnsSumOfTransactions() throws Exception {
+
+        String responseBody = mockMvc
+                .perform(MockMvcRequestBuilders.get("/test?clientId=1234"))
+                .andExpect(status().is(200))
+                .andReturn().getResponse().getContentAsString();
+
+        TestClientResponse response = objectMapper.readValue(responseBody, TestClientResponse.class);
+
+        assertNull(response.getErrors());
+        assertEquals(new BigDecimal("1.00"), response.getSumTransactions());
+
+    }
+
+    @Test
+    void whenQueryInvalidId_statusIsNotFound() throws Exception {
+
+        String responseBody = mockMvc
+                .perform(MockMvcRequestBuilders.get("/test?clientId=ABC321"))
+                .andExpect(status().is(404))
+                .andReturn().getResponse().getContentAsString();
+
+        TestClientResponse response = objectMapper.readValue(responseBody, TestClientResponse.class);
+
+        assertNotNull(response.getErrors());
+        assertEquals(1, response.getErrors().size());
+        assertEquals("ABC321", response.getErrors().get(0).getValue());
+
+    }
+}


### PR DESCRIPTION
Add simple implementation of domain-service (credit-application).
Add data source for 1) mock response 2) calling external data-service.
Test mock response.
[AB#2286](https://deloittedigitalat.visualstudio.com/38398c5c-11b2-4e64-98b5-5af5e65d6e82/_workitems/edit/2286)