### PR TITLE
Update docker build for data-access-services

### DIFF
--- a/data-access-services/docker-build.sh
+++ b/data-access-services/docker-build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Build and verify all modules
-mvn clean package
+mvn clean install
 
 # Build containers for individual services
 mvn -f ./transactions-service/pom.xml \


### PR DESCRIPTION
Call `mvn install` instead of `package` to make sure that the multi-module project is installed to local repo while building.