### PR TITLE
Changing services for aws deployment

### DIFF
--- a/data-access-services/accounts-service/src/main/resources/application-prod.yml
+++ b/data-access-services/accounts-service/src/main/resources/application-prod.yml
@@ -1,0 +1,12 @@
+# PROD profile
+# - Postgres database access configured with env variables
+spring:
+  datasource:
+    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST}:5432/accounts
+    username: ${DB_USER}
+    password: ${DB_PWD}
+  jpa:
+    hibernate:
+      ddl-auto: validate

--- a/data-access-services/transactions-service/src/main/resources/application-prod.yml
+++ b/data-access-services/transactions-service/src/main/resources/application-prod.yml
@@ -1,0 +1,12 @@
+# PROD profile
+# - Postgres database access configured with env variables
+spring:
+  datasource:
+    database-platform: org.hibernate.dialect.PostgreSQL10Dialect
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST}:5432/transactions
+    username: ${DB_USER}
+    password: ${DB_PWD}
+  jpa:
+    hibernate:
+      ddl-auto: validate

--- a/domain-service/credit-application/src/it/java/at/deloittedigital/core_banking/credit/CoreBankingCreditApplicationIT.java
+++ b/domain-service/credit-application/src/it/java/at/deloittedigital/core_banking/credit/CoreBankingCreditApplicationIT.java
@@ -10,10 +10,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-@SpringBootTest(properties = {"core-banking.credit.datasource.mode=mock"})
+@SpringBootTest
+@ActiveProfiles("dev")
 @AutoConfigureMockMvc
 class CoreBankingCreditApplicationIT {
 

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/config/WebConfiguration.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/config/WebConfiguration.java
@@ -1,0 +1,14 @@
+package at.deloittedigital.core_banking.credit.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedMethods("*");
+    }
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/MockCreditDataService.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/MockCreditDataService.java
@@ -24,8 +24,14 @@ public class MockCreditDataService implements CreditDataService {
     @Override
     public CreditData query(String clientId) {
         try (InputStream is = readMockData()) {
+            // In mock version we return either hardcoded data for the test client,
+            // or empty data for any other clients (=not found)
             QueryResult result = objectMapper.readValue(is, QueryResult.class);
-            return result.getCreditData().filter(clientId);
+            if (result.getCreditData().contains(clientId)) {
+                return result.getCreditData();
+            } else {
+                return CreditData.EMPTY;
+            }
         } catch (IOException e) {
             throw new RuntimeException("Error while loading mock response", e);
         }

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/RemoteCreditDataService.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/RemoteCreditDataService.java
@@ -7,16 +7,26 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @Log4j2
 @ConditionalOnProperty(name = "core-banking.credit.datasource.mode", havingValue = "remote")
 public class RemoteCreditDataService implements CreditDataService {
+
+    // todo hardcoded graphql request for testing
+    private static final String TEST_QUERY =
+            "{ client(id:\\\"%s\\\"){clientId,firstName,lastName,accounts{transactions{amount}}} }";
+    private static final String TEST_REQUEST =
+            "{ \"query\": \"%s\" }";
 
     private final RestTemplate restTemplate;
     private final URI dataServiceUrl;
@@ -31,19 +41,36 @@ public class RemoteCreditDataService implements CreditDataService {
     @Override
     public CreditData query(String clientId) {
         // for testing basic service integration
+        // todo graphql client
         // todo error handling, non-blocking req, response validity check
-        URI endpoint = UriComponentsBuilder
-                .fromUri(dataServiceUrl)
-                .path("/query")
-                .build().toUri();
-        HttpEntity<String> request = new HttpEntity<>("{}");
-        log.info("POST {}", endpoint);
-        QueryResult result = restTemplate.exchange(endpoint, HttpMethod.POST, request, QueryResult.class).getBody();
-        if (result == null) {
-            throw new RestClientException("Data service null response");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String query = String.format(TEST_QUERY, clientId);
+        String body = String.format(TEST_REQUEST, query);
+        HttpEntity<String> request = new HttpEntity<>(body, headers);
+
+        log.info("POST {}, '{}'", dataServiceUrl, body);
+        ResponseEntity<QueryResult>
+                response = restTemplate.exchange(dataServiceUrl, HttpMethod.POST, request, QueryResult.class);
+
+        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+            return CreditData.EMPTY;
+        } else {
+            QueryResult result = response.getBody();
+            if (validResponse(result)) {
+                return result.getCreditData();
+            } else {
+                log.error("Invalid response from data-service {}", result);
+                throw new RestClientException("Invalid response from data-service");
+            }
         }
-        log.info("Received data {}", result.getCreditData());
-        return result.getCreditData().filter(clientId);
+    }
+
+    private boolean validResponse(QueryResult result) {
+        // todo validation api
+        return result != null
+                && result.getCreditData() != null
+                && CollectionUtils.isEmpty(result.getErrors());
     }
 
 }

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/CreditData.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/CreditData.java
@@ -1,8 +1,5 @@
 package at.deloittedigital.core_banking.credit.datasource.model;
 
-import static java.util.stream.Collectors.toList;
-
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,14 +8,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CreditData {
-    private List<Client> clients;
+
+    public static final CreditData EMPTY = new CreditData();
+
+    private Client client;
 
     public boolean isEmpty() {
-        return clients == null || clients.isEmpty();
+        return client == null;
     }
 
-    public CreditData filter(String clientId) {
-        List<Client> clients = this.clients.stream().filter(c -> clientId.equals(c.getClientId())).collect(toList());
-        return new CreditData(clients);
+    public boolean contains(String clientId) {
+        return client != null && clientId.equals(client.getClientId());
     }
 }

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/QueryError.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/QueryError.java
@@ -1,0 +1,14 @@
+package at.deloittedigital.core_banking.credit.datasource.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class QueryError {
+
+    private String message;
+    // todo graphql api error cause
+}

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/QueryResult.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/datasource/model/QueryResult.java
@@ -1,6 +1,7 @@
 package at.deloittedigital.core_banking.credit.datasource.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,4 +13,7 @@ public class QueryResult {
 
     @JsonProperty("data")
     private CreditData creditData;
+
+    private List<QueryError> errors;
+
 }

--- a/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/domain/CreditApplicationService.java
+++ b/domain-service/credit-application/src/main/java/at/deloittedigital/core_banking/credit/domain/CreditApplicationService.java
@@ -24,7 +24,7 @@ public class CreditApplicationService {
         if (data.isEmpty()) {
             return Optional.empty();
         } else {
-            Client c = data.getClients().get(0);
+            Client c = data.getClient();
             return Optional.of(clientInfoMapper.map(c));
         }
     }

--- a/domain-service/credit-application/src/main/resources/application-dev.yml
+++ b/domain-service/credit-application/src/main/resources/application-dev.yml
@@ -1,0 +1,5 @@
+core-banking:
+  credit:
+    datasource:
+      mode: "mock"
+      url: ""

--- a/domain-service/credit-application/src/main/resources/application-prod.yml
+++ b/domain-service/credit-application/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+core-banking:
+  credit:
+    datasource:
+      mode: "remote"
+      url: "http://data-service.core-banking:8000/graphql"

--- a/domain-service/credit-application/src/main/resources/application-test.yml
+++ b/domain-service/credit-application/src/main/resources/application-test.yml
@@ -1,0 +1,5 @@
+core-banking:
+  credit:
+    datasource:
+      mode: "remote"
+      url: "http://localhost:4000/graphql"

--- a/domain-service/credit-application/src/main/resources/application.yml
+++ b/domain-service/credit-application/src/main/resources/application.yml
@@ -1,11 +1,11 @@
+spring:
+  profiles:
+    active: dev
+
 server:
   port: 8070
   error:
     whitelabel:
       enabled: false
-
-core-banking:
-  credit:
-    datasource:
-      mode: "mock"
-      url: ""
+  servlet:
+    contextPath: /api

--- a/domain-service/credit-application/src/main/resources/mock-credit-data.json
+++ b/domain-service/credit-application/src/main/resources/mock-credit-data.json
@@ -1,23 +1,21 @@
 {
   "data": {
-    "clients": [
-      {
-        "clientId": "1234",
-        "firstName": "John",
-        "lastName": "Smith",
-        "accounts": [
-          {
-            "transactions": [
-              {
-                "amount": 12.99
-              },
-              {
-                "amount": -11.99
-              }
-            ]
-          }
-        ]
-      }
-    ]
+    "client": {
+      "clientId": "1234",
+      "firstName": "John",
+      "lastName": "Smith",
+      "accounts": [
+        {
+          "transactions": [
+            {
+              "amount": 12.99
+            },
+            {
+              "amount": -11.99
+            }
+          ]
+        }
+      ]
+    }
   }
 }

--- a/domain-service/credit-application/src/test/java/at/deloittedigital/core_banking/credit/datasource/MockCreditDataServiceTest.java
+++ b/domain-service/credit-application/src/test/java/at/deloittedigital/core_banking/credit/datasource/MockCreditDataServiceTest.java
@@ -21,8 +21,8 @@ public class MockCreditDataServiceTest {
 
         // THEN
         // todo not checking all fields, only added this test for verifying project setup
-        assertThat(result.getClients()).hasSize(1);
-        Client client = result.getClients().get(0);
+        assertThat(result.getClient()).isNotNull();
+        Client client = result.getClient();
         assertThat(client.getClientId()).isEqualTo(clientId);
 
     }


### PR DESCRIPTION
- Add prod profiles to data acess services with db access params as env variables
- Integrate credit-application-service to graphql api of data-service
- Update tests and mock data format to conform graphql api results
- Create test and prod profiles for credit-application-service
- Related to [AB#2284](https://deloittedigitalat.visualstudio.com/38398c5c-11b2-4e64-98b5-5af5e65d6e82/_workitems/edit/2284)
